### PR TITLE
Allow to sig4 request for other services than AWS

### DIFF
--- a/awsauth.go
+++ b/awsauth.go
@@ -187,6 +187,7 @@ const (
 	envSecretKey       = "AWS_SECRET_KEY"
 	envSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
 	envSecurityToken   = "AWS_SECURITY_TOKEN"
+	envRegion          = "AWS_REGION"
 )
 
 var (

--- a/common.go
+++ b/common.go
@@ -35,7 +35,9 @@ func serviceAndRegion(host string) (service string, region string) {
 
 	parts := strings.Split(host, ".")
 	if !strings.Contains(host, "amazonaws.com") {
-		region = os.Getenv(envRegion)
+		if os.Getenv(envRegion) != "" {
+			region = os.Getenv(envRegion)
+		}
 		service = "execute-api"
 	} else if len(parts) == 4 {
 		// Either service.region.amazonaws.com or virtual-host.region.amazonaws.com

--- a/common.go
+++ b/common.go
@@ -34,7 +34,10 @@ func serviceAndRegion(host string) (service string, region string) {
 	service = "s3"
 
 	parts := strings.Split(host, ".")
-	if len(parts) == 4 {
+	if !strings.Contains(host, "amazonaws.com") {
+		region = os.Getenv(envRegion)
+		service = "execute-api"
+	} else if len(parts) == 4 {
 		// Either service.region.amazonaws.com or virtual-host.region.amazonaws.com
 		if parts[1] == "s3" {
 			service = "s3"


### PR DESCRIPTION
# Context

Currently it is only possible to sign requests for AWS services. The purpose of this PR is to allow to sign requests with sig4 for other services than AWS, for instance if you use sig4 on front of your own APIs with a custom domain name.

# Implementation

If the hostname doesn't contains `amazonaws.com` then we are signing a request for a custom API. 

As it is not possible to deduce the `region` from the hostname in this case it is take from a `AWS_REGION` environment variable.

Also the service is set to `execute-api`.

# Tests

I have not find any public service which match the requirements (API with sig4 auth and a custom domain name) so i cannot provide a test case. However it works for our APIs.
